### PR TITLE
Add api-proctor-delay-seconds input

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -390,7 +390,7 @@ jobs:
         run: |
           docker-compose pull --include-deps ${{ steps.get-services.outputs.services }}
           docker-compose up -d ${{ steps.get-services.outputs.services }}
-          sleep {{ inputs.api-proctor-delay-seconds }}s
+          sleep ${{ inputs.api-proctor-delay-seconds }}s
 
       - name: Run API Proctor tests
         env:

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -15,6 +15,15 @@ on:
         description: Run the API Proctor tests associated with this repo.
         default: true
         type: boolean
+      api-proctor-delay-seconds:
+        description: >
+          The number of seconds to sleep after starting services in Docker
+          before running the API Proctor tests, to give services enough startup
+          time. Set this to the smallest value such that the tests pass
+          consistently. This input will hopefully become unnecessary in the
+          future, if we can await service readiness automatically.
+        default: 0
+        type: number
       api-proctor-timeout-minutes:
         description: The timeout in minutes for running API Proctor tests.
         default: 30
@@ -381,7 +390,7 @@ jobs:
         run: |
           docker-compose pull --include-deps ${{ steps.get-services.outputs.services }}
           docker-compose up -d ${{ steps.get-services.outputs.services }}
-          sleep 1m
+          sleep {{ inputs.api-proctor-delay-seconds }}s
 
       - name: Run API Proctor tests
         env:


### PR DESCRIPTION
### Dependencies

None.

### Documentation

- [CR feedback](https://github.com/nicheinc/actions/pull/3#discussion_r1036262179)

### Description

Adds an input for configuring the duration of the `sleep` call after starting services before running API Proctor tests.

### Testing Considerations

Should probably test this out in `search`, which is the repo that currently needs the delay for the sake of Elasticsearch startup.

### Deployment 

To be merged into the `v0` branch.

### Versioning

Minor - merge into the `v0` branch.